### PR TITLE
feat(agent): optional session context via --context for Cursor 

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "cursor-plugin-cc",
   "owner": {
-    "name": "Felipe"
+    "name": "felipeinf"
   },
   "metadata": {
     "description": "Claude Code plugin for delegating tasks to Cursor.",
@@ -13,7 +13,7 @@
       "description": "Delegate tasks to Cursor from Claude Code and manage background jobs.",
       "version": "0.8.10",
       "author": {
-        "name": "Felipe"
+        "name": "felipeinf"
       },
       "source": "./plugins/cursor"
     }

--- a/plugins/cursor/.claude-plugin/plugin.json
+++ b/plugins/cursor/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "0.8.10",
   "description": "Delegate tasks to Cursor from Claude Code and manage background jobs.",
   "author": {
-    "name": "Felipe"
+    "name": "felipeinf"
   },
   "license": "MIT"
 }

--- a/plugins/cursor/agents/cursor-agent.md
+++ b/plugins/cursor/agents/cursor-agent.md
@@ -4,7 +4,7 @@ description: Proactively use when Claude Code should hand a substantial coding t
 model: sonnet
 tools: Bash
 skills:
-  - cursor-cli-runtime
+  - cursor-companion-contract
   - cursor-prompting
 ---
 

--- a/plugins/cursor/commands/agent.md
+++ b/plugins/cursor/commands/agent.md
@@ -1,14 +1,36 @@
 ---
 description: Delegate a task to Cursor via the cursor-agent subagent (background by default)
-argument-hint: "[--wait|--background] [--continue|--fresh] [--model <name>] [--mode plan|ask] [--read-only] <task>"
+argument-hint: "[--context] [--wait|--background] [--continue|--fresh] [--model <name>] [--mode plan|ask] [--read-only] <task>"
 allowed-tools: Bash(node:*), AskUserQuestion, Agent
 ---
 
-Invoke the `cursor:cursor-agent` subagent via the `Agent` tool (`subagent_type: "cursor:cursor-agent"`), forwarding the raw user request as the prompt.
+Invoke the `cursor:cursor-agent` subagent via the `Agent` tool (`subagent_type: "cursor:cursor-agent"`), forwarding the natural-language prompt as described below (raw task text with routing flags stripped, or the combined context-plus-task string when `--context` was used).
 The final user-visible response must be Cursor's output verbatim.
 
 Raw user request:
 $ARGUMENTS
+
+Context flag:
+
+- If the request includes `--context`, handle it only in this command. Do not forward `--context` to the subagent or to `task`.
+- Before anything else below, if `--context` was present: build a short (~5 lines, one per field) context block from this Claude session’s recent conversation and prepend it to the user’s task text. Use that combined string as the natural-language prompt passed to the subagent. Remove `--context` from both routing flags and task text.
+- Fixed template:
+
+```text
+## Context (from Claude session)
+- Goal: <one line>
+- Recent decisions: <one line>
+- Files touched: <comma-separated paths, or "n/a">
+- Current state: <one line>
+- Open question / blocker: <one line, or "none">
+
+## Task
+<original user task text>
+```
+
+- Block rules: facts already stated in the conversation only; no invention. No literal transcript, no code snippets, no secrets, keys, or tokens. If a field does not apply, use `n/a` or `none`. If nothing concrete exists to summarize (e.g. first message in session), omit the context block and tell the user briefly before continuing.
+- If the user combines `--context` with `--continue` or `--resume`, still prepend the block as above.
+- `--context` is exclusive to this slash command and is never a `cursor-agent` or companion flag.
 
 Execution mode:
 
@@ -16,6 +38,7 @@ Execution mode:
 - Otherwise (no flag or explicit `--background`), run the `cursor:cursor-agent` subagent in the background. Background is the default.
 - `--background` and `--wait` are execution flags for Claude Code. Do not forward them to `task`, and do not treat them as part of the natural-language task text.
 - `--model`, `--mode`, and `--read-only` are runtime flags. Preserve them for the forwarded `task` call, but do not treat them as part of the natural-language task text.
+- `--context` is handled only here (see Context flag); never forward it to `task`.
 - If the request includes `--continue`, `--resume <id>`, or `--fresh`, do not ask whether to continue. The user already chose.
 - Otherwise, before starting Cursor, check for a resumable thread from this Claude session by running:
 
@@ -37,7 +60,8 @@ Operating rules:
 
 - The subagent is a thin forwarder only. It should use one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/cursor-companion.mjs" task ...` and return that command's stdout as-is.
 - Return the Cursor companion stdout verbatim to the user.
-- Do not paraphrase, summarize, rewrite, or add commentary before or after it.
+- Do not paraphrase, summarize, rewrite, or add commentary before or after Cursor’s stdout (except building the optional session context block when `--context` was requested).
 - Default to write-capable runs. `--read-only` suppresses `--force`.
 - If the helper reports that Cursor is missing or unauthenticated, stop and tell the user to run `/cursor:setup`.
 - If the user did not supply a request, ask what Cursor should investigate or fix.
+

--- a/plugins/cursor/skills/cursor-companion-contract/SKILL.md
+++ b/plugins/cursor/skills/cursor-companion-contract/SKILL.md
@@ -1,17 +1,19 @@
 ---
-name: cursor-cli-runtime
-description: Internal helper contract for calling the cursor-companion runtime from Claude Code
+name: cursor-companion-contract
+description: Contract for invoking cursor-companion task runs from the cursor-agent subagent only.
 user-invocable: false
 ---
 
-# Cursor Runtime
+# Cursor companion contract
 
 Use this skill only inside the `cursor:cursor-agent` subagent.
 
 Primary helper:
+
 - `node "${CLAUDE_PLUGIN_ROOT}/scripts/cursor-companion.mjs" task "<raw arguments>"`
 
 Rules:
+
 - Invoke the companion with one `Bash` call and return stdout unchanged.
 - Never read files, inspect repository state, grep, monitor, poll, fetch results, or cancel jobs.
 - Do not call `setup`, `status`, `result`, or `cancel`.

--- a/plugins/cursor/skills/cursor-prompting/SKILL.md
+++ b/plugins/cursor/skills/cursor-prompting/SKILL.md
@@ -11,3 +11,4 @@ user-invocable: false
 - Ask Cursor for a written plan before edits when scope is unclear.
 - Keep delegated prompts under roughly 2k tokens.
 - Do not add Claude-side conclusions or file inspection results you did not gather.
+- When `/cursor:agent` was invoked with `--context`, the natural-language prompt already includes a fixed five-line session block (Goal, Recent decisions, Files touched, Current state, Open question). Facts only; no transcripts, secrets, or code. If nothing concrete exists to summarize, that block is omitted by the slash command—do not invent one in the subagent.


### PR DESCRIPTION
- Document Context flag and combined prompt in /cursor:agent\n- Align cursor-prompting skill with injected session block\n- Fix plugin YAML frontmatter where needed\n- Set plugin and marketplace author to felipeinf